### PR TITLE
Interactive eeg animation

### DIFF
--- a/app/app/src/main/java/com/example/myapplication/MainActivity.java
+++ b/app/app/src/main/java/com/example/myapplication/MainActivity.java
@@ -377,7 +377,7 @@ public class MainActivity extends AppCompatActivity {
                         if (msg.arg1 > 0) {
                         pulse.setConcentration((msg.arg1 / 10) + 1);
                         } else {
-                            pulse.setConcentration(0);
+                            pulse.setConcentration(1);
                         }
                         break;
                     default:


### PR DESCRIPTION
This is the same as #120 , where it was possible for `int concentration` from PulseView to be set to 0 in one of the MainActivity methods. This would have crashed the app because `int concentration` is used to divide other variables.
The method has been changed to default to a setter = 1.